### PR TITLE
systemd module: Update namespace camptocamp->puppet

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     archive: 'puppet/archive'
     concat: 'puppetlabs/concat'
     promtail: 'grafana/promtail'
-    systemd: 'camptocamp/systemd'
+    systemd: 'puppet/systemd'
     stdlib: 'puppetlabs/stdlib'
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'

--- a/metadata.json
+++ b/metadata.json
@@ -23,8 +23,8 @@
       "version_requirement": ">= 4.25.0 < 9.0.0"
     },
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 1.1.1 < 4.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 3.3.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
the systemd module got migrated to Vox Pupuli. The new lower version
boundary is the oldest version in the Vox Pupuli namespace.