### PR TITLE
Don't notify the loki service when we don't manage it ourselves.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,7 @@ class loki::config {
   }
   -> concat { $config_file:
     ensure => present,
-    notify => Service['loki'],
+    notify => $loki::service::service_notify,
   }
 
   concat::fragment { 'loki_config_header':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class loki::install {
           ensure  => link,
           target  => $binary_path,
           require => File[$binary_path],
-          notify  => Service['loki'],
+          notify  => $loki::service::service_notify,
         ;
       }
 
@@ -80,7 +80,7 @@ class loki::install {
           ensure  => link,
           target  => $binary_path_logcli,
           require => File[$binary_path_logcli],
-          notify  => Service['loki'],
+          notify  => $loki::service::service_notify,
         ;
       }
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -35,5 +35,8 @@ class loki::service {
       name     => $::loki::service_name,
       provider => $::loki::service_provider,
     }
+    $service_notify = [Service['loki']]
+  } else {
+    $service_notify = []
   }
 }


### PR DESCRIPTION
When we don't let the module manage the loki service, we also don't want to notify said service.

Otherwise this will cause errors since the service might not exist, or not with that specific name. We can assume that if someone explicitely sets $manage_service to false, they will handle the service reloading/restarting themselves.