### PR TITLE
add backend target

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -62,6 +62,16 @@ class loki::config {
     }
   }
 
+  # Configures the common config hash.
+  # [common: <common_config>]
+  if $loki::common_config_hash {
+    concat::fragment { 'common':
+      target  => $config_file,
+      content => $loki::distributor_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      order   => '4',
+    }
+  }
+
   # Configures the distributor.
   # [distributor: <distributor_config>]
   if $loki::distributor_config_hash {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,7 @@ class loki (
   String[1] $version,
   Optional[Boolean] $auth_enabled = undef,
   Optional[Hash] $chunk_store_config_hash = undef,
-  Optional[Hash] $loki::common_config_hash = undef,
+  Optional[Hash] $common_config_hash = undef,
   Optional[Hash] $compactor_config_hash = undef,
   Optional[Hash] $distributor_config_hash = undef,
   Optional[Hash] $frontend_worker_config_hash = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class loki (
   Optional[Hash] $runtime_config_hash = undef,
   Optional[Hash] $server_config_hash = undef,
   Optional[Hash] $table_manager_config_hash = undef,
-  Optional[Enum['all', 'compactor', 'distributor', 'ingester', 'querier', 'query-scheduler', 'ingester-querier', 'query-frontend', 'index-gateway', 'ruler', 'table-manager', 'read', 'write']] $target = undef,
+  Optional[Enum['all', 'compactor', 'distributor', 'ingester', 'querier', 'query-scheduler', 'ingester-querier', 'query-frontend', 'index-gateway', 'ruler', 'table-manager', 'read', 'write', 'backend']] $target = undef,
   Optional[Hash] $tracing_config_hash = undef,
   Optional[Hash] $memberlist_config_hash = undef,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class loki (
   String[1] $version,
   Optional[Boolean] $auth_enabled = undef,
   Optional[Hash] $chunk_store_config_hash = undef,
+  Optional[Hash] $loki::common_config_hash = undef,
   Optional[Hash] $compactor_config_hash = undef,
   Optional[Hash] $distributor_config_hash = undef,
   Optional[Hash] $frontend_worker_config_hash = undef,


### PR DESCRIPTION
According to [the latest docs](https://grafana.com/docs/loki/latest/get-started/components/), there is now also a "backend" target for the simple scalable deployment mode that does compaction and some other stuff, which looks like it was added/separated out from the other components in 2.9.x.