### PR TITLE
add common_config_hash parameter

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -15,4 +15,4 @@ loki::service_name: loki
 loki::service_provider: systemd
 loki::service_ensure: running
 loki::user: loki
-loki::version: 'v2.3.0'
+loki::version: 'v2.4.0'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -52,6 +52,16 @@ class loki::config {
     order   => '03',
   }
 
+  # Configure common settings section
+  # [common: <common_config>]
+  if $loki::common_config_hash {
+    concat::fragment { 'loki_common_config':
+      target  => $config_file,
+      content => $loki::common_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      order   => '09',
+    }
+  }
+
   # Configures the server of the launched module(s).
   # [server: <server_config>]
   if $loki::server_config_hash {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,9 @@
 # @example Minimal example, creates a standalone loki instance (not desinged for production).
 #     class{ 'loki':
 #       auth_enabled                => false,
+#       common_config_hash          => {'common' => {
+#                                         'path_prefix' => '/var/lib/loki',
+#                                      }},
 #       schema_config_hash          => {'schema_config' => {
 #                                         'configs' => [{
 #                                           'from'         => '2020-05-15',
@@ -67,6 +70,7 @@ class loki (
   Optional[Enum['all', 'compactor', 'distributor', 'ingester', 'querier', 'query-scheduler', 'ingester-querier', 'query-frontend', 'index-gateway', 'ruler', 'table-manager', 'read', 'write']] $target = undef,
   Optional[Hash] $tracing_config_hash = undef,
   Optional[Hash] $memberlist_config_hash = undef,
+  Optional[Hash] $common_config_hash = undef,
 ) {
   if $manage_service {
     $service_notify = [Service['loki']]

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -9,6 +9,7 @@ describe 'with default parameters ', if: ['debian', 'redhat', 'ubuntu'].include?
   }
   -> class{ 'loki':
     auth_enabled                => false,
+    common_config_hash          => {'common' => {'path_prefix' => '/var/lib/loki',}},
     schema_config_hash          => {'schema_config' => {'configs' => [{'from' => '2020-05-15', 'store' => 'boltdb', 'object_store' => 'filesystem', 'schema' => 'v11', 'index' =>{'prefix' => 'index_', 'period' => '168h'}}]}},
     storage_config_hash         => {'storage_config' => { 'boltdb' => { 'directory' => '/var/lib/loki/index',}, 'filesystem' => {'directory' => '/var/lib/loki/chunks',},},},
     server_config_hash          => {'server' => {'http_listen_port' => 3100, 'http_listen_address' => $facts['networking']['ip']},},


### PR DESCRIPTION
Add support for configuring the `common` section within the `loki` config. The common section is available since Loki 2.4.0