### PR TITLE
remove promtail dependency

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,6 +16,10 @@
 * `loki::install`: A short summary of the purpose of this class
 * `loki::service`: A short summary of the purpose of this class
 
+### Functions
+
+* [`loki::strip_yaml_header`](#loki--strip_yaml_header): A function to strip the --- from the beginning of a string
+
 ### Data types
 
 * [`Loki::Target`](#Loki--Target): List of loki components
@@ -370,6 +374,50 @@ Data type: `Optional[Hash]`
 Common configuration to be shared between multiple modules.
 
 Default value: `undef`
+
+## Functions
+
+### <a name="loki--strip_yaml_header"></a>`loki::strip_yaml_header`
+
+Type: Ruby 4.x API
+
+A function to strip the --- from the beginning of a string
+
+#### Examples
+
+##### 
+
+```puppet
+concat::fragment { 'loki_common_config':
+  target  => $config_file,
+  content => $loki::common_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
+  order   => '09',
+}
+```
+
+#### `loki::strip_yaml_header(String $yaml_string)`
+
+A function to strip the --- from the beginning of a string
+
+Returns: `String` Returns the string with the leading header stripped off
+
+##### Examples
+
+###### 
+
+```puppet
+concat::fragment { 'loki_common_config':
+  target  => $config_file,
+  content => $loki::common_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
+  order   => '09',
+}
+```
+
+##### `yaml_string`
+
+Data type: `String`
+
+A string that may start with the ---'s used to denote a YAML file
 
 ## Data types
 

--- a/lib/puppet/functions/loki/strip_yaml_header.rb
+++ b/lib/puppet/functions/loki/strip_yaml_header.rb
@@ -1,0 +1,22 @@
+# A function to strip the --- from the beginning of a string
+Puppet::Functions.create_function(:'loki::strip_yaml_header') do
+  # @param yaml_string
+  #   A string that may start with the ---'s used to denote a YAML file
+  # @return [String]
+  #   Returns the string with the leading header stripped off
+  # @example
+  #   concat::fragment { 'loki_common_config':
+  #     target  => $config_file,
+  #     content => $loki::common_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
+  #     order   => '09',
+  #   }
+  #
+  dispatch :strip_header do
+    param 'String', :yaml_string
+    return_type 'String'
+  end
+
+  def strip_header(yaml_string)
+    yaml_string.gsub(%r{^---\s}, '')
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -53,7 +53,7 @@ class loki::config {
   if $loki::common_config_hash {
     concat::fragment { 'loki_common_config':
       target  => $config_file,
-      content => $loki::common_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::common_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '09',
     }
   }
@@ -63,7 +63,7 @@ class loki::config {
   if $loki::server_config_hash {
     concat::fragment { 'loki_server_config':
       target  => $config_file,
-      content => $loki::server_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::server_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '10',
     }
   }
@@ -73,7 +73,7 @@ class loki::config {
   if $loki::distributor_config_hash {
     concat::fragment { 'loki_distributor_config':
       target  => $config_file,
-      content => $loki::distributor_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::distributor_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '11',
     }
   }
@@ -84,7 +84,7 @@ class loki::config {
   if $loki::querier_config_hash {
     concat::fragment { 'loki_querier_config':
       target  => $config_file,
-      content => $loki::querier_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::querier_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '12',
     }
   }
@@ -94,7 +94,7 @@ class loki::config {
   if $loki::query_frontend_config_hash {
     concat::fragment { 'loki_query_frontend_config':
       target  => $config_file,
-      content => $loki::query_frontend_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::query_frontend_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '13',
     }
   }
@@ -105,7 +105,7 @@ class loki::config {
   if $loki::query_range_config_hash {
     concat::fragment { 'loki_queryrange_config':
       target  => $config_file,
-      content => $loki::query_range_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::query_range_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '14',
     }
   }
@@ -115,7 +115,7 @@ class loki::config {
   if $loki::ruler_config_hash {
     concat::fragment { 'loki_ruler_config':
       target  => $config_file,
-      content => $loki::ruler_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::ruler_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '15',
     }
   }
@@ -126,7 +126,7 @@ class loki::config {
   if $loki::ingester_client_config_hash {
     concat::fragment { 'loki_ingester_client_config':
       target  => $config_file,
-      content => $loki::ingester_client_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::ingester_client_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '16',
     }
   }
@@ -137,7 +137,7 @@ class loki::config {
   if $loki::ingester_config_hash {
     concat::fragment { 'loki_ingester_config':
       target  => $config_file,
-      content => $loki::ingester_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::ingester_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '17',
     }
   }
@@ -146,7 +146,7 @@ class loki::config {
   # [storage_config: <storage_config>]
   concat::fragment { 'loki_storage_config':
     target  => $config_file,
-    content => $loki::storage_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+    content => $loki::storage_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
     order   => '18',
   }
 
@@ -155,7 +155,7 @@ class loki::config {
   if $loki::chunk_store_config_hash {
     concat::fragment { 'loki_chunk_store_config':
       target  => $config_file,
-      content => $loki::chunk_store_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::chunk_store_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '19',
     }
   }
@@ -164,7 +164,7 @@ class loki::config {
   # [schema_config: <schema_config>]
   concat::fragment { 'loki_schema_config':
     target  => $config_file,
-    content => $loki::schema_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+    content => $loki::schema_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
     order   => '20',
   }
 
@@ -173,7 +173,7 @@ class loki::config {
   if $loki::limits_config_hash {
     concat::fragment { 'loki_limits_config':
       target  => $config_file,
-      content => $loki::limits_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::limits_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '21',
     }
   }
@@ -183,7 +183,7 @@ class loki::config {
   if $loki::compactor_config_hash {
     concat::fragment { 'loki_compactor_config':
       target  => $config_file,
-      content => $loki::compactor_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::compactor_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '22',
     }
   }
@@ -194,7 +194,7 @@ class loki::config {
   if $loki::frontend_worker_config_hash {
     concat::fragment { 'loki_frontend_worker_config':
       target  => $config_file,
-      content => $loki::frontend_worker_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::frontend_worker_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '23',
     }
   }
@@ -204,7 +204,7 @@ class loki::config {
   if $loki::table_manager_config_hash {
     concat::fragment { 'loki_table_manager_config':
       target  => $config_file,
-      content => $loki::table_manager_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::table_manager_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '24',
     }
   }
@@ -214,7 +214,7 @@ class loki::config {
   if $loki::runtime_config_hash {
     concat::fragment { 'loki_runtime_config':
       target  => $config_file,
-      content => $loki::runtime_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::runtime_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '25',
     }
   }
@@ -224,7 +224,7 @@ class loki::config {
   if $loki::tracing_config_hash {
     concat::fragment { 'loki_tracing_config':
       target  => $config_file,
-      content => $loki::tracing_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::tracing_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '26',
     }
   }
@@ -234,7 +234,7 @@ class loki::config {
   if $loki::memberlist_config_hash {
     concat::fragment { 'loki_memberlist_config':
       target  => $config_file,
-      content => $loki::memberlist_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::memberlist_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '27',
     }
   }
@@ -245,7 +245,7 @@ class loki::config {
   if $loki::query_scheduler_config_hash {
     concat::fragment { 'loki_query_scheduler_config':
       target  => $config_file,
-      content => $loki::query_scheduler_config_hash.promtail::to_yaml.promtail::strip_yaml_header,
+      content => $loki::query_scheduler_config_hash.stdlib::to_yaml.loki::strip_yaml_header,
       order   => '28',
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -17,10 +17,6 @@
       "version_requirement": ">= 6.0.0 < 10.0.0"
     },
     {
-      "name": "grafana/promtail",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
-    },
-    {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 10.0.0"
     },


### PR DESCRIPTION
`stdlib` offers a `to_yaml` function, which replaces `promtail::to_yaml`. As the only remaining dependency of the `promtail` module, would be the `strip_yaml_header` function, I've just copied into this module.

One dependency less to maintain :smile: 