### PR TITLE
Make config file name configurable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -73,6 +73,7 @@ The following parameters are available in the `loki` class:
 
 * [`bin_dir`](#-loki--bin_dir)
 * [`config_dir`](#-loki--config_dir)
+* [`config_file`](#-loki--config_file)
 * [`data_dir`](#-loki--data_dir)
 * [`group`](#-loki--group)
 * [`install_method`](#-loki--install_method)
@@ -120,6 +121,12 @@ path to install binary file.
 Data type: `Stdlib::Absolutepath`
 
 path to install configuration file.
+
+##### <a name="-loki--config_file"></a>`config_file`
+
+Data type: `String[1]`
+
+file to install configuration in.
 
 ##### <a name="-loki--data_dir"></a>`data_dir`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -6,6 +6,7 @@ lookup_options:
 loki::group: loki
 loki::bin_dir: '/usr/local/bin'
 loki::config_dir: '/etc/loki'
+loki::config_file: 'loki.yaml'
 loki::data_dir: '/var/lib/loki'
 loki::install_method: archive
 loki::manage_service: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@
 #
 # @api private
 class loki::config {
-  $config_file = "${loki::config_dir}/loki.yaml"
+  $config_file = "${loki::config_dir}/${loki::config_file}"
 
   if $loki::manage_user {
     File[$loki::config_dir] {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@
 #
 # @param bin_dir path to install binary file.
 # @param config_dir path to install configuration file.
+# @param config_file file to install configuration in.
 # @param data_dir path where loki data will be stored.
 # @param group Group that owns loki files.
 # @param install_method How to install loki.
@@ -74,6 +75,7 @@
 class loki (
   Stdlib::Absolutepath $bin_dir,
   Stdlib::Absolutepath $config_dir,
+  String[1] $config_file,
   Stdlib::Absolutepath $data_dir,
   String[1] $group,
   Enum['archive','package'] $install_method,

--- a/templates/loki.service.epp
+++ b/templates/loki.service.epp
@@ -5,7 +5,7 @@ Documentation=https://github.com/grafana/loki
 [Service]
 Type=simple
 User=<%= $loki::user %>
-ExecStart=<%= $loki::bin_dir %>/loki -config.file <%= $loki::config_dir %>/loki.yaml
+ExecStart=<%= $loki::bin_dir %>/loki -config.file <%= $loki::config_dir %>/<%= $loki::config_file %>
 Restart=always
 RestartSec=30s
 


### PR DESCRIPTION
This makes the loki.yaml config file name
configurable since some packaging might
drop their own systemd unit file that
uses another path and we need to be
able to change the config file name
and not only the config dir.